### PR TITLE
Sequence cleanup, consistency.

### DIFF
--- a/src/choreograph/Sequence.hpp
+++ b/src/choreograph/Sequence.hpp
@@ -335,22 +335,6 @@ Sequence<T> Sequence<T>::slice( Time from, Time to )
 }
 
 //=================================================
-// Convenience functions.
-//=================================================
-
-template<typename T>
-SequenceRef<T> createSequence( T &&initialValue )
-{
-  return std::make_shared<Sequence<T>>( std::forward<T>( initialValue ) );
-}
-
-template<typename T>
-SequenceRef<T> createSequence( const T &initialValue )
-{
-  return std::make_shared<Sequence<T>>( initialValue );
-}
-
-//=================================================
 // Sequence Decorator Phrase.
 //=================================================
 

--- a/src/choreograph/Sequence.hpp
+++ b/src/choreograph/Sequence.hpp
@@ -192,7 +192,7 @@ template<typename T>
 template<template <typename> class PhraseT, typename... Args>
 Sequence<T>& Sequence<T>::then( const T &value, Time duration, Args&&... args )
 {
-  _phrases.emplace_back( std::make_unique<PhraseT<T>>( duration, this->getEndValue(), value, std::forward<Args>(args)... ) );
+  _phrases.emplace_back( std::make_shared<PhraseT<T>>( duration, this->getEndValue(), value, std::forward<Args>(args)... ) );
   _duration += duration;
 
   return *this;

--- a/tests/Choreograph_test.cpp
+++ b/tests/Choreograph_test.cpp
@@ -948,13 +948,13 @@ TEST_CASE( "Separate component interpolation", "[sequence]" )
 
   SECTION( "Over- and Under-fill Separate Easings" )
   {
-    auto sequence = createSequence( vec3( 10.0f ) );
+    Sequence<vec3> sequence( vec3(10.0f) );
     // The real test here is that we don't crash when creating or using this sequence.
-    sequence->then<RampTo3>( vec3( 1.0f ), 1.0f, EaseInOutQuad() ).then<RampTo3>( vec3( 5.0f ), 1.0f, EaseInQuad(), EaseNone(), EaseInAtan(), EaseInBack() );
+    sequence.then<RampTo3>( vec3( 1.0f ), 1.0f, EaseInOutQuad() ).then<RampTo3>( vec3( 5.0f ), 1.0f, EaseInQuad(), EaseNone(), EaseInAtan(), EaseInBack() );
 
-    REQUIRE( sequence->getValue( 0.0f ).x == sequence->getValue( 0.0f ).y );
-    REQUIRE( sequence->getValue( 1.5f ).x != sequence->getValue( 1.5f ).y );
-    REQUIRE( sequence->getValue( 1.5f ).y != sequence->getValue( 1.5f ).z );
+    REQUIRE( sequence.getValue( 0.0f ).x == sequence.getValue( 0.0f ).y );
+    REQUIRE( sequence.getValue( 1.5f ).x != sequence.getValue( 1.5f ).y );
+    REQUIRE( sequence.getValue( 1.5f ).y != sequence.getValue( 1.5f ).z );
   }
 } // Separate Component Easing
 


### PR DESCRIPTION
Use make_shared.
No need for convenience methods that dynamically-allocate Sequences.