### PR TITLE
Include <algorithm> for std::remove_if

### DIFF
--- a/src/choreograph/detail/VectorManipulation.hpp
+++ b/src/choreograph/detail/VectorManipulation.hpp
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 namespace choreograph
 {
 namespace detail


### PR DESCRIPTION
For some reason clang includes this already, but GCC does not.