### PR TITLE
Sequence Splicing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,7 @@
+# Choreograph
+
+A simple, modern C++ animation and timing library.  
+
+## Unreleased (v0.4.0)
+Changed default TimeType to be alias to double.
+Added `splice()` method to Sequence.

--- a/src/choreograph/Sequence.hpp
+++ b/src/choreograph/Sequence.hpp
@@ -128,7 +128,11 @@ public:
 
   /// Returns a Sequence containing the phrases between Times from and to.
   /// Partial phrases at the beginning and end are wrapped in ClipPhrases.
-  Sequence slice( Time from, Time to );
+  Sequence slice( Time from, Time to ) const;
+
+  /// Splices a collection of Phrases into the sequence at \a start_index.
+  /// Removes elements from.
+  void splice( size_t start_index, size_t elements_to_remove, const std::vector<PhraseRef<T>> &phrases_to_insert );
 
   //
   // Phrase<T> Equivalents.
@@ -161,6 +165,8 @@ public:
 
   /// Returns the number of phrases in the Sequence.
   size_t getPhraseCount() const { return _phrases.size(); }
+  size_t size() const { return _phrases.size(); }
+  bool   empty() const { return _phrases.empty(); }
 
   /// Calculate and return the Sequence duration.
   Time calcDuration() const;
@@ -220,7 +226,7 @@ Sequence<T>& Sequence<T>::then( const Sequence<T> &next )
 template<typename T>
 T Sequence<T>::getValue( Time atTime ) const
 {
-  if( atTime < 0.0f )
+  if( atTime < 0 )
   {
     return _initial_value;
   }
@@ -303,7 +309,7 @@ Time Sequence<T>::getTimeAtInflection( size_t inflection ) const
 }
 
 template<typename T>
-Sequence<T> Sequence<T>::slice( Time from, Time to )
+Sequence<T> Sequence<T>::slice( Time from, Time to ) const
 {
   if( _phrases.empty() ) {
     return Sequence<T>( PhraseRef<T>( std::make_shared<Hold<T>>( to - from, _initial_value ) ) );
@@ -332,6 +338,22 @@ Sequence<T> Sequence<T>::slice( Time from, Time to )
     Time t = getTimeAtInflection( points.first );
     return Sequence<T>( PhraseRef<T>( std::make_shared<ClipPhrase<T>>( first, from - t, to - t ) ) );
   }
+}
+
+template<typename T>
+void Sequence<T>::splice( size_t start_index, size_t elements_to_remove, const std::vector<PhraseRef<T> > &phrases_to_insert )
+{
+  start_index = std::min( start_index, _phrases.size() );
+  auto last_index = std::min( start_index + elements_to_remove, _phrases.size() );
+  if( elements_to_remove > 0 ) {
+    auto begin = _phrases.begin() + start_index;
+    auto end = _phrases.begin() + last_index;
+    _phrases.erase( begin, end );
+  }
+
+  auto begin = _phrases.begin() + start_index;
+  _phrases.insert( begin, phrases_to_insert.begin(), phrases_to_insert.end() );
+  _duration = calcDuration();
 }
 
 //=================================================

--- a/src/choreograph/Sequence.hpp
+++ b/src/choreograph/Sequence.hpp
@@ -134,6 +134,14 @@ public:
   /// Removes elements from.
   void splice( size_t start_index, size_t elements_to_remove, const std::vector<PhraseRef<T>> &phrases_to_insert );
 
+  /// Returns a shared_ptr to the phrase at the requested index.
+  /// Throws an exception if the index provided is out of bounds.
+  PhraseRef<T> getPhraseAtIndex( size_t index ) { return _phrases.at( index ); }
+  /// Returns the phrase at the requested time.
+  /// If the time is past duration, returns the last phrase in the Sequence.
+  /// If there are no phrases in the sequence, behavior is undefined (asserts in debug builds).
+  PhraseRef<T> getPhraseAtTime( Time time );
+
   //
   // Phrase<T> Equivalents.
   //
@@ -221,6 +229,33 @@ Sequence<T>& Sequence<T>::then( const Sequence<T> &next )
   _duration = calcDuration();
 
   return *this;
+}
+
+template<typename T>
+PhraseRef<T> Sequence<T>::getPhraseAtTime( Time time )
+{
+  assert( ! _phrases.empty() );
+  if( time < 0 )
+  {
+    return _phrases.front();
+  }
+  else if ( time > this->getDuration() )
+  {
+    return _phrases.back();
+  }
+
+  for( const auto &phrase : _phrases )
+  {
+    if( phrase->getDuration() < time ) {
+      time -= phrase->getDuration();
+    }
+    else {
+      return phrase;
+    }
+  }
+
+  // Should be unreachable.
+  return _phrases.back();
 }
 
 template<typename T>

--- a/src/choreograph/TimeType.h
+++ b/src/choreograph/TimeType.h
@@ -43,7 +43,7 @@ namespace choreograph
 /// Switch to double if you need more precision.
 ///
 
-using Time = float;
+using Time = double;
 
 /// Wrap \a time past \a duration around \a inflectionPoint.
 inline Time wrapTime( Time time, Time duration, Time inflectionPoint=0.0f )

--- a/src/choreograph/phrase/Ramp.hpp
+++ b/src/choreograph/phrase/Ramp.hpp
@@ -74,8 +74,12 @@ public:
   }
 
   T getStartValue() const override { return _start_value; }
-
   T getEndValue() const override { return _end_value; }
+
+  void setStartValue( const T &value ) { _start_value = value; }
+  void setEndValue( const T &value ) { _end_value = value; }
+
+  void setLerpFn( const LerpFn &lerp_fn ) { _lerp_fn = lerp_fn; }
 
 private:
   T       _start_value;

--- a/tests/Choreograph_test.cpp
+++ b/tests/Choreograph_test.cpp
@@ -202,6 +202,32 @@ TEST_CASE( "Sequences" )
     REQUIRE( sequence.getValue( 1.0f ) == sequence.getValue( 4.0f ) );
   }
 
+  SECTION( "Phrases can be spliced into sequences." )
+  {
+    REQUIRE( sequence.size() == 3 );
+    sequence.splice( 1, 1, {} ); // 0-1, 10-100
+    REQUIRE( sequence.size() == 2 );
+
+    auto phrase = makeRamp( 10.0f, 50.0f, 1.0 );
+    auto another = makeReverse<float>( phrase );
+    sequence.splice( 1, 0, { phrase, another } ); // 0-1, 10-50, 50-10, 10-100
+    REQUIRE( sequence.size() == 4 );
+    REQUIRE( sequence.getDuration() == 4.0 );
+    REQUIRE( sequence.getValue( 2.0 ) == 50.0f );
+
+    phrase->setEndValue( 500.0f );
+    REQUIRE( sequence.getValue( 2.0 ) == 500.0f );
+  }
+
+  SECTION( "Sequences prevent incorrect splicing." )
+  {
+    sequence.splice( 100, 100, {} );
+    REQUIRE( sequence.size() == 3 );
+
+    sequence.splice( 0, 100, {} );
+    REQUIRE( sequence.size() == 0 );
+  }
+
 }
 
 //==========================================
@@ -669,19 +695,19 @@ TEST_CASE( "Callbacks" )
       .updateFn( [&updateTarget, &target, &updateCount] ( Motion<float> &m ) { updateTarget = target() / 2.0f; updateCount++; } )
       .finishFn( [&endCalled] (Motion<float> &) { endCalled = true; } );
 
-    const float step = timeline.timeUntilFinish() / 10.0f;
+    const float step = timeline.timeUntilFinish() / 10.0;
     timeline.step( step );
     REQUIRE( startCalled );
     REQUIRE( updateCount == 1 );
-    REQUIRE( updateTarget == (target / 2.0f) );
+    REQUIRE( updateTarget == (target / 2.0) );
 
-    for( int i = 0; i < 10; i += 1 ) {
+    for( int i = 0; i < 9; i += 1 ) {
       REQUIRE_FALSE( endCalled );
       timeline.step( step );
     }
 
     REQUIRE( endCalled );
-    REQUIRE( updateCount == 11 );
+    REQUIRE( updateCount == 10 );
   }
 
   SECTION( "Functions can be cued by sequence inflection points." )

--- a/tests/Choreograph_test.cpp
+++ b/tests/Choreograph_test.cpp
@@ -217,6 +217,8 @@ TEST_CASE( "Sequences" )
 
     phrase->setEndValue( 500.0f );
     REQUIRE( sequence.getValue( 2.0 ) == 500.0f );
+    REQUIRE( sequence.getPhraseAtTime( 1.8 ) == phrase );
+    REQUIRE( sequence.getPhraseAtIndex( 2 ) == another );
   }
 
   SECTION( "Sequences prevent incorrect splicing." )


### PR DESCRIPTION
Splice phrases into an existing `Sequence`.
Lets you modify a `Sequence` in-place.
Accessors to `PhraseRef`s inside a `Sequence`.

From the unit tests:
```c++
auto phrase = makeRamp( 10.0f, 50.0f, 1.0 );
auto another = makeReverse<float>( phrase );
sequence.splice( 1, 0, { phrase, another } );
sequence.getPhraseAtIndex( 1 ) == phrase; // => true
```