### PR TITLE
Fix inflection cues when crossing very small timesteps

### DIFF
--- a/src/choreograph/Motion.hpp
+++ b/src/choreograph/Motion.hpp
@@ -166,11 +166,15 @@ void Motion<T>::update()
   if( ! _inflection_callbacks.empty() )
   {
     auto points = _source.getInflectionPoints( previousTime(), time() );
-    if( points.first != points.second ) {
-      // We just crossed an inflection point...
-      auto crossed = std::max( points.first, points.second );
-      for( const auto &fn : _inflection_callbacks ) {
-        if( fn.first == crossed ) {
+    if( points.first != points.second )
+    {
+      // We just crossed into the second inflection point
+      auto top = std::max( points.first, points.second );
+      auto bottom = std::min( points.first, points.second );
+      for( const auto &fn : _inflection_callbacks )
+      {
+        auto inflection = fn.first;
+        if( inflection > bottom && inflection <= top ) {
           fn.second( *this );
         }
       }

--- a/tests/Choreograph_test.cpp
+++ b/tests/Choreograph_test.cpp
@@ -6,7 +6,7 @@
 
 // If true, will test vec2 and vec3 animation.
 // You must have GLM in the search path for this to work.
-#define TEST_WITH_GLM_VECTORS 1
+#define TEST_WITH_GLM_VECTORS 0
 
 using namespace std;
 using namespace choreograph;
@@ -720,6 +720,7 @@ TEST_CASE( "Callbacks" )
   {
     int c1 = 0;
     int c2 = 0;
+    bool triggered = false;
 
     timeline.apply( &target )
       .hold( 0.5f )
@@ -732,6 +733,10 @@ TEST_CASE( "Callbacks" )
       } )
       .then<RampTo>( 2.0f, 1.0f );
 
+    timeline.append( &target )
+      .onInflection( [&triggered] (Motion<float> &m) { triggered = true; } )
+      .hold( 1.0 );
+
     timeline.step( 0.49f );
     timeline.step( 0.02f );
     REQUIRE( c1 == 1 );
@@ -743,6 +748,9 @@ TEST_CASE( "Callbacks" )
     timeline.jumpTo( 1.49f );
     REQUIRE( c2 == 2 );
     REQUIRE( c1 == 1 );
+
+    timeline.step( 2.0f );
+    REQUIRE( triggered );
   }
 
   SECTION( "It is safe to add and cancel motions from Cues and Motion callbacks." )

--- a/tests/Choreograph_test.cpp
+++ b/tests/Choreograph_test.cpp
@@ -720,7 +720,7 @@ TEST_CASE( "Callbacks" )
   {
     int c1 = 0;
     int c2 = 0;
-    bool triggered = false;
+    int trigger_count = 0;
 
     timeline.apply( &target )
       .hold( 0.5f )
@@ -734,7 +734,9 @@ TEST_CASE( "Callbacks" )
       .then<RampTo>( 2.0f, 1.0f );
 
     timeline.append( &target )
-      .onInflection( [&triggered] (Motion<float> &m) { triggered = true; } )
+      .onInflection( [&trigger_count] (Motion<float> &m) { trigger_count += 1; } )
+      .hold( 0.001 )
+      .onInflection( [&trigger_count] (Motion<float> &m) { trigger_count += 1; } )
       .hold( 1.0 );
 
     timeline.step( 0.49f );
@@ -750,7 +752,7 @@ TEST_CASE( "Callbacks" )
     REQUIRE( c1 == 1 );
 
     timeline.step( 2.0f );
-    REQUIRE( triggered );
+    REQUIRE( trigger_count == 2 );
   }
 
   SECTION( "It is safe to add and cancel motions from Cues and Motion callbacks." )

--- a/tests/choreograph/Configuration.h
+++ b/tests/choreograph/Configuration.h
@@ -38,6 +38,6 @@ namespace choreograph
 /// Switch to double if you need more precision.
 ///
 
-using Time = float;
+using Time = double;
 
 } // namespace choreograph

--- a/tests/choreograph/Configuration.h
+++ b/tests/choreograph/Configuration.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014 David Wicks, sansumbrella.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace choreograph
+{
+
+///
+/// Choreograph uses float to measure Time by default.
+/// Add this file to your project include path as Configuration.h
+/// This is set up as an alias so it's easier to change out if needed.
+/// Floats lose precision pretty quickly, but they're fast and don't take up much space.
+/// Switch to double if you need more precision.
+///
+
+using Time = float;
+
+} // namespace choreograph


### PR DESCRIPTION
Previously crossing inflection points that spanned time shorter than the given timestep would not be called.
This is now fixed, so all inflection points crossed by a given timestep are triggered.