### PR TITLE
Shared timeline controls point to the unique TimelineItem.

### DIFF
--- a/src/choreograph/Timeline.cpp
+++ b/src/choreograph/Timeline.cpp
@@ -166,7 +166,7 @@ TimelineOptions Timeline::addShared( const TimelineItemRef &shared )
 {
   auto item = detail::make_unique<PassthroughTimelineItem>( shared );
   item->setRemoveOnFinish( _default_remove_on_finish );
-  auto &ref = *shared;
+  auto &ref = *item;
 
   if( _updating ) {
     _queue.emplace_back( std::move( item ) );


### PR DESCRIPTION
Makes cancelling the item behave more intuitively, as it
cancels that specific instance of being on a timeline, rather
than cancelling the shared timeline forever.