### PR TITLE
Motion callback simplification

### DIFF
--- a/samples/src/SamplesApp.cpp
+++ b/samples/src/SamplesApp.cpp
@@ -84,7 +84,7 @@ void SamplesApp::loadSample( int index )
     _timeline.apply( _previous_scene->getOffsetOutput() )
       .hold( cooldown )
       .then<RampTo>( vec2( vanish_x, 0.0f ), 0.4f, EaseInQuad() )
-      .finishFn( [this] ( Motion<vec2> &m ) {
+      .finishFn( [this] {
         _previous_scene.reset(); // get rid of previous scene
       } );
   }
@@ -101,7 +101,7 @@ void SamplesApp::loadSample( int index )
     _current_scene->pause();
 
     _timeline.apply( _current_scene->getOffsetOutput() ).hold( 0.2f + cooldown ).then<RampTo>( vec2( 0 ), 0.66f, EaseOutQuint() )
-    .finishFn( [this] ( Motion<vec2> &m ) {
+    .finishFn( [this] {
       _current_scene->resume();
     } );
 

--- a/samples/src/samples/BezierConstruction.cpp
+++ b/samples/src/samples/BezierConstruction.cpp
@@ -66,12 +66,12 @@ void BezierConstruction::setup()
 
   // Apply the bezier_point animation to our curve point variable.
   group->apply<vec2>( &_curve_point, bezier_point )
-    .startFn( [this] ( Motion<vec2> &m ) {
+    .startFn( [this] {
       _segments.clear();
       _segments.push_back( _curve_points[0] );
     } )
-    .updateFn( [this] ( Motion<vec2> &m ) {
-      _segments.push_back( m.getCurrentValue() );
+    .updateFn( [this] {
+      _segments.push_back( _curve_point );
     } );
 
   // When all our animations finish, cue the group to restart after a delay.

--- a/samples/src/samples/Quaternions.cpp
+++ b/samples/src/samples/Quaternions.cpp
@@ -38,11 +38,14 @@ void Quaternions::setup()
   // Apply a ramp to the continous orientation.
   timeline().apply( &_continuous_orientation )
     .then<RampTo>( glm::angleAxis( (float)(randFloat() * M_PI * 2), randVec3() ), 1.0f, EaseInOutCubic() )
-    .finishFn( [this] (Motion<quat> &m) {
+    .finishFn( [this] () {
       // Extend this sequence into the future.
-      m.getSequence().then<RampTo>( glm::angleAxis( (float)(randFloat() * M_PI * 2), randVec3() ), 1.0f, EaseInOutCubic() );
-      // Erase all completed phrases from this sequence.
-      m.cutPhrasesBefore( m.time() );
+      auto m = _continuous_orientation.inputPtr();
+      if (m) {
+        m->getSequence().then<RampTo>( glm::angleAxis( (float)(randFloat() * M_PI * 2), randVec3() ), 1.0f, EaseInOutCubic() );
+        // Erase all completed phrases from this sequence.
+        m->cutPhrasesBefore( m->time() );
+      }
     } );
 }
 

--- a/samples/src/samples/Repetition.cpp
+++ b/samples/src/samples/Repetition.cpp
@@ -44,14 +44,14 @@ void Repetition::setup()
 
   Output<vec2>  loopTarget;
   timeline().apply( &loopTarget, leftToRight )
-    .finishFn( [] ( Motion<vec2> &m ) {
+    .finishFn( [&m = *loopTarget.inputPtr()] {
       m.resetTime();
     } );  // Motion should play forever.
 
 
   Output<vec2>  pingPongTarget;
   timeline().apply( &pingPongTarget, leftToRight )
-    .finishFn( [] ( Motion<vec2> &m ) {
+    .finishFn( [&m = *pingPongTarget.inputPtr()] {
       // reverse Motion direction on finish.
       m.setPlaybackSpeed( m.getPlaybackSpeed() * -1 );
       // Start each cycle from "zero" to keep in sync with loopTarget timing.
@@ -60,12 +60,12 @@ void Repetition::setup()
 
   Output<vec2>  pingPongSlowerTarget;
   timeline().apply( &pingPongSlowerTarget, leftToRight )
-    .finishFn( [] ( Motion<vec2> &m ) {
+    .finishFn( [&m = *pingPongSlowerTarget.inputPtr()] {
       // Reverse and slow Motion on finish.
       m.setPlaybackSpeed( m.getPlaybackSpeed() * -0.9f );
       // If we're unbearably slow, stop looping.
       if( std::abs( m.getPlaybackSpeed() ) < 0.2f ) {
-        m.setFinishFn( [] ( Motion<vec2> &m ) {} );
+        m.setFinishFn( [] {} );
       }
       else {
         m.resetTime();

--- a/src/choreograph/Motion.hpp
+++ b/src/choreograph/Motion.hpp
@@ -52,7 +52,7 @@ class Motion : public TimelineItem
 public:
   using MotionT       = Motion<T>;
   using SequenceT     = Sequence<T>;
-  using Callback      = std::function<void (MotionT&)>;
+  using Callback      = std::function<void ()>;
 
   Motion() = delete;
 
@@ -154,10 +154,10 @@ void Motion<T>::update()
   if( _start_fn )
   {
     if( forward() && time() > 0.0f && previousTime() <= 0.0f ) {
-      _start_fn( *this );
+      _start_fn();
     }
     else if( backward() && time() < getDuration() && previousTime() >= getDuration() ) {
-      _start_fn( *this );
+      _start_fn();
     }
   }
 
@@ -175,7 +175,7 @@ void Motion<T>::update()
       {
         auto inflection = fn.first;
         if( inflection > bottom && inflection <= top ) {
-          fn.second( *this );
+          fn.second();
         }
       }
     }
@@ -183,16 +183,16 @@ void Motion<T>::update()
 
   if( _update_fn )
   {
-    _update_fn( *this );
+    _update_fn();
   }
 
   if( _finish_fn )
   {
     if( forward() && time() >= getDuration() && previousTime() < getDuration() ) {
-      _finish_fn( *this );
+      _finish_fn();
     }
     else if( backward() && time() <= 0.0f && previousTime() > 0.0f ) {
-      _finish_fn( *this );
+      _finish_fn();
     }
   }
 }

--- a/tests/Benchmarks_test.cpp
+++ b/tests/Benchmarks_test.cpp
@@ -112,7 +112,7 @@ TEST_CASE( "Choreograph Timeline Basic Performance" )
   }
   Timer create_in_place( true );
   for( auto &target : targets ) {
-    choreograph_timeline.apply( &target ).then<RampTo>( vec2( 10.0f ), 1.0f ).startFn( [] (Motion<vec2> &) {} ).updateFn( [] ( Motion<vec2> &m ) { m.getCurrentValue() + vec2(1); } ).finishFn( [] (Motion<vec2> &) {} );
+    choreograph_timeline.apply( &target ).then<RampTo>( vec2( 10.0f ), 1.0f ).startFn( [] {} ).updateFn( [&m = *target.inputPtr()] { m.getCurrentValue() + vec2(1); } ).finishFn( [] {} );
   }
   create_in_place.stop();
   printTiming( "Creating Motions with Callbacks in place", create_in_place.getSeconds() * 1000 );
@@ -142,7 +142,7 @@ TEST_CASE( "Choreograph Timeline Basic Performance" )
   Sequence<vec2> sequence( vec2( 1.0f ) );
   sequence.then<RampTo>( vec2( 5.0f ), 1.0f ).then<RampTo>( vec2( 10.0f, 6.0f ), 0.5f );
   for( auto &target : targets ) {
-    choreograph_timeline.apply( &target, sequence ).startFn( [] (Motion<vec2> &) {} ).updateFn( [] ( Motion<vec2> &m ) { m.getCurrentValue() + vec2(1); } ).finishFn( [] (Motion<vec2> &) {} );
+    choreograph_timeline.apply( &target, sequence ).startFn( [] {} ).updateFn( [&m = *target.inputPtr()] { m.getCurrentValue() + vec2(1); } ).finishFn( [] {} );
   }
 
   create_copy.stop();

--- a/tests/Grouping_test.cpp
+++ b/tests/Grouping_test.cpp
@@ -44,13 +44,13 @@ TEST_CASE( "Motion Groups" )
 
     group_timeline.apply( &target )
       .then<RampTo>( 10, 1.0f )
-      .startFn( [&start_count] (Motion<int> &m) {
+      .startFn( [&start_count] () {
         start_count += 1;
       } )
-      .updateFn( [&update_count] (Motion<int> &m) {
+      .updateFn( [&update_count] () {
         update_count += 1;
       } )
-      .finishFn( [&finish_count] (Motion<int> &m) {
+      .finishFn( [&finish_count] () {
         finish_count += 1;
       } );
 

--- a/tests/Timeline_test.cpp
+++ b/tests/Timeline_test.cpp
@@ -104,9 +104,9 @@ TEST_CASE( "Callbacks" )
     int           updateCount = 0;
     float         updateTarget = 0;
 
-    options.startFn( [&startCalled] (Motion<float> &) { startCalled = true; } )
-      .updateFn( [&updateTarget, &target, &updateCount] ( Motion<float> &m ) { updateTarget = target() / 2.0f; updateCount++; } )
-      .finishFn( [&endCalled] (Motion<float> &) { endCalled = true; } );
+    options.startFn( [&startCalled] () { startCalled = true; } )
+      .updateFn( [&updateTarget, &target, &updateCount] () { updateTarget = target() / 2.0f; updateCount++; } )
+      .finishFn( [&endCalled] () { endCalled = true; } );
 
     const float step = timeline.timeUntilFinish() / 10.0;
     timeline.step( step );
@@ -132,18 +132,18 @@ TEST_CASE( "Callbacks" )
     timeline.apply( &target )
       .hold( 0.5f )
       // inflects around 0.5
-      .onInflection( [&c1] (Motion<float> &m) { c1 += 1; } )
+      .onInflection( [&c1] () { c1 += 1; } )
       .then<RampTo>( 3.0f, 1.0f )
       // inflects around 1.5
-      .onInflection( [&c2] (Motion<float> &m) {
+      .onInflection( [&c2] () {
         c2 += 1;
       } )
       .then<RampTo>( 2.0f, 1.0f );
 
     timeline.append( &target )
-      .onInflection( [&trigger_count] (Motion<float> &m) { trigger_count += 1; } )
+      .onInflection( [&trigger_count] () { trigger_count += 1; } )
       .hold( 0.001 )
-      .onInflection( [&trigger_count] (Motion<float> &m) { trigger_count += 1; } )
+      .onInflection( [&trigger_count] () { trigger_count += 1; } )
       .hold( 1.0 );
 
     timeline.step( 0.49f );
@@ -168,7 +168,7 @@ TEST_CASE( "Callbacks" )
 
     SECTION( "Add Motion from Motion callback." )
     {
-      options.startFn( [&] (Motion<float> &) {
+      options.startFn( [&] () {
         timeline.apply( &t2, sequence );
       } );
 
@@ -183,7 +183,7 @@ TEST_CASE( "Callbacks" )
       // Play t2 motion twice as fast as previous, disconnect target on finish.
       timeline.apply( &t2, sequence )
         .playbackSpeed( 2.0f )
-        .finishFn( [&target] (Motion<float> &) {
+        .finishFn( [&target] () {
           target.disconnect();
       } );
 

--- a/tests/xcode/ChoreographTests.xcodeproj/project.pbxproj
+++ b/tests/xcode/ChoreographTests.xcodeproj/project.pbxproj
@@ -435,6 +435,7 @@
 		1515D28319C5D774002CB6A6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = "$(CINDER_PATH_IN_BLOCKS)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -471,6 +472,7 @@
 		1515D28419C5D774002CB6A6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CINDER_PATH = "$(CINDER_PATH_IN_BLOCKS)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;


### PR DESCRIPTION
Motion callbacks no longer pass through the current Motion reference. This simplifies the common use case.

If you need a reference to the motion, capture it or the output object in your lambda using `output.inputPtr()`.