### PR TITLE
Add convenience rampTo function to timeline options.

### DIFF
--- a/src/choreograph/TimelineOptions.hpp
+++ b/src/choreograph/TimelineOptions.hpp
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "Motion.hpp"
+#include "phrase/Ramp.hpp"
 #include "Cue.h"
 
 namespace choreograph
@@ -162,6 +163,9 @@ public:
   SelfT& hold( Time duration ) { _sequence.template then<Hold>( _sequence.getEndValue(), duration ); return *this; }
 
 	SelfT& holdUntil( Time time ) { _sequence.template then<Hold>( _sequence.getEndValue(), std::max<Time>( time - _sequence.getDuration(), 0 ) ); return *this; }
+
+  template<typename... Args>
+  SelfT& rampTo( const T &value, Time duration, Args&&... args ) { _sequence.template then<RampTo>( value, duration, std::forward<Args>(args)... ); return *this; }
 
   //=================================================
   // Accessors to Motion and Sequence.

--- a/tests/Timeline_test.cpp
+++ b/tests/Timeline_test.cpp
@@ -21,6 +21,23 @@ TEST_CASE( "Timeline" )
     .then<RampTo>( 10.0f, 1.0f )
     .then<RampTo>( 100.0f, 1.0f );
 
+  SECTION( "Convenience methods create equivalent timeline to explicit methods" )
+  {
+    Output<float> a, b;
+    timeline.apply(&a)
+      .set(0.0f)
+      .rampTo(5.0f, 1.0, EaseOutQuad());
+
+    timeline.apply(&b)
+      .set(0.0f)
+      .then<RampTo>(5.0f, 1.0, EaseOutQuad());
+
+    for (auto t = 0.0; t < 1.0; t += 0.2) {
+      timeline.jumpTo(t);
+      REQUIRE(a == b);
+    }
+  }
+
   SECTION( "Output<T> pointers can be controlled via Timeline." )
   {
     Output<float> target = 0.0f;


### PR DESCRIPTION
New syntactic sugar.

```c++
timeline.apply(&thing).then<RampTo>(5, 1);
// New equivalent:
timeline.apply(&thing).rampTo(5, 1);
```