### PR TITLE
Include chrono to TimeTypes

### DIFF
--- a/src/choreograph/TimeType.h
+++ b/src/choreograph/TimeType.h
@@ -32,6 +32,7 @@
 #include <functional>
 #include <vector>
 #include <array>
+#include <chrono>
 
 namespace choreograph
 {


### PR DESCRIPTION
Included <chrono.h> in TimeTypes header. My Baxalta lobby app complained when I tried to build it on ubuntu.
